### PR TITLE
Expand delete workflow

### DIFF
--- a/entities/record_delete_dataclass.py
+++ b/entities/record_delete_dataclass.py
@@ -1,8 +1,0 @@
-from dataclasses import dataclass, field
-from typing import List
-
-@dataclass
-class DeleteRecord:
-    student_id: str
-    admission_ids: List[str] = field(default_factory=list)
-    following_ids: List[str] = field(default_factory=list)

--- a/main.py
+++ b/main.py
@@ -63,12 +63,15 @@ parser.add_argument(
     dest="recent_updates",
     action="store_true"
 )
+
 args = parser.parse_args()
 
 
-def _delete_records() -> None:
-    api = OvergradAPIPaginator("students", args.grad_year)
-    run_delete_records_workflow(api, args.grad_year)
+def _delete_records(endpoints: List[Endpoint]) -> None:
+    for endpoint in endpoints:
+        if endpoint.name in ["students", "admissions", "followings"]:
+            api = OvergradAPIPaginator(endpoint.name, args.grad_year)
+            run_delete_records_workflow(api, endpoint, args.grad_year)
 
 
 def _get_recent_table_updates_dates() -> dict:
@@ -154,11 +157,11 @@ def _record_updates(endpoints: List[Endpoint]):
 
 def main():
     notifications.extend_job_name(f" - {args.grad_year}")
+    endpoints = _setup_endpoints()
     if args.delete_records:
         notifications.extend_job_name(" - delete records")
-        _delete_records()
+        _delete_records(endpoints)
     else:
-        endpoints = _setup_endpoints()
         _record_updates(endpoints)
 
 

--- a/workflows/delete_records.py
+++ b/workflows/delete_records.py
@@ -3,7 +3,6 @@ import os
 from typing import Union
 
 from entities.endpoints import Endpoint
-from entities.record_delete_dataclass import DeleteRecord
 from entities.overgrad_api import OvergradAPIPaginator
 
 from gbq_connector import BigQueryClient

--- a/workflows/delete_records.py
+++ b/workflows/delete_records.py
@@ -32,6 +32,7 @@ def _delete_admissions_records(record: DeleteRecord, year):
     else:
         logging.info(f"No admissions records to delete")
 
+
 def _delete_followings_records(record: DeleteRecord, year):
     if record.following_ids:
         for r in record.following_ids:
@@ -62,24 +63,22 @@ def _get_dw_student_ids(year: str) -> Union[set, None]:
     else:
         return None
 
-# admissions
-# SELECT * FROM `kae-cloud-kippnorcal.norcal_analytics.stg_og__admissions` where overgrad_student_id = 999999
 
 def _find_student_admissions(record: DeleteRecord):
-    # SELECT * FROM `kae-cloud-kippnorcal.norcal_analytics.stg_og__followings` where overgrad_student_id = 999999
     query = f"SELECT overgrad_application_id FROM `{project}.{dataset}.stg_og__admissions` where overgrad_student_id = {record.student_id}"
     df = gbq.query(query)
     if df is not None:
         result = df["overgrad_application_id"].to_list()
         record.admission_ids = result
 
+
 def _find_student_followings(record: DeleteRecord):
-    # SELECT * FROM `kae-cloud-kippnorcal.norcal_analytics.stg_og__followings` where overgrad_student_id = 999999
     query = f"SELECT overgrad_following_id FROM `{project}.{dataset}.stg_og__followings` where overgrad_student_id = {record.student_id}"
     df = gbq.query(query)
     if df is not None:
         result = df["overgrad_following_id"].to_list()
         record.following_ids = result
+
 
 def run_delete_records_workflow(api: OvergradAPIPaginator, grad_year: str) -> None:
     # get records from DW

--- a/workflows/delete_records.py
+++ b/workflows/delete_records.py
@@ -2,6 +2,7 @@ import logging
 import os
 from typing import Union
 
+from entities.endpoints import Endpoint
 from entities.record_delete_dataclass import DeleteRecord
 from entities.overgrad_api import OvergradAPIPaginator
 
@@ -80,7 +81,7 @@ def _find_student_followings(record: DeleteRecord):
         record.following_ids = result
 
 
-def run_delete_records_workflow(api: OvergradAPIPaginator, grad_year: str) -> None:
+def run_delete_records_workflow(api: OvergradAPIPaginator, endpoint: Endpoint, grad_year: str) -> None:
     # get records from DW
     dw_student_ids = _get_dw_student_ids(grad_year)
     if dw_student_ids is not None:


### PR DESCRIPTION
The delete workflow use to look for student records that were deleted and then delete admissions and following records associated with a deleted student.

This new workflow just looks to delete student, admission, and following records individually. The reason for this is that, as an example, sometimes an admission record might be deleted for a student, but the student wasn't deleted.